### PR TITLE
Terraform 0.15 support by marking outputs as sensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.tfstate
 *.tfstate.*
 
+*.terraform.lock.hcl
+
 # Crash log files
 crash.log
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.44.0
+  rev: v1.48.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="unreleased"></a>
-## [Unreleased]
+<a name="2.0.0"></a>
+## [2.0.0] - 2021-04-19
+
+- Add support for Terraform 0.15 by setting sensitive outputs to have the sensitive=true flag. (https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values)
+- Terraform version requirement bumped to 0.14.5 in order to support sensitive values
+
+<a name="1.0.2"></a>
+## [1.0.2] - 2020-11-09
+
+- Update module to remove 0.14 limit
+
+<a name="1.0.1"></a>
+## [1.0.1] - 2020-08-06
 
 - Update module versions to support v3 provider
 - add CHANGELOG.md
@@ -15,5 +26,6 @@ All notable changes to this project will be documented in this file.
 - Add initial module configuration
 - Initial commit
 
-
-[Unreleased]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.0...HEAD
+[2.0.0]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.2...2.0.0
+[1.0.2]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.1...1.0.2
+[1.0.1]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Terraform module creating encrypted and non-encrypted AWS SSM parameters
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master` branch.
+Terraform 0.14.5. Pin module version to `~> v2.0`.
+Terraform 0.12 - 0.14.4. Pin module version to `~> v1.0`.
+Submit pull-requests to `master` branch.
 
 ## Usage
 
@@ -42,7 +44,8 @@ module "ssm-parameters" {
 
 ## Assumptions
 
-Module is to be used with Terraform > 0.12.
+Module v1.0 is to be used with Terraform > 0.12.
+Module v2.0+ is to be used with Terraform > 0.14.5
 
 ## Examples
 
@@ -57,35 +60,45 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.41 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.41 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.41 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.41 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssm_parameter.parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.secure_parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| advanced\_tier | List of parameter names that should have tier set to Advanced | `list(string)` | `[]` | no |
-| kms\_key\_id | The KMS key to use for encryption | `string` | `""` | no |
-| name\_prefix | Path used for each SSM parameter created by the module | `any` | n/a | yes |
-| parameters | Non-encrypted parameters | `map(any)` | `{}` | no |
-| prevent\_overwrite | List of parameter names to prevent overwrite for | `list(string)` | `[]` | no |
-| secure\_parameters | Secure parameters | `map(any)` | `{}` | no |
-| tags | n/a | `map(any)` | `{}` | no |
+| <a name="input_advanced_tier"></a> [advanced\_tier](#input\_advanced\_tier) | List of parameter names that should have tier set to Advanced | `list(string)` | `[]` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The KMS key to use for encryption | `string` | `""` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Path used for each SSM parameter created by the module | `any` | n/a | yes |
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | Non-encrypted parameters | `map(any)` | `{}` | no |
+| <a name="input_prevent_overwrite"></a> [prevent\_overwrite](#input\_prevent\_overwrite) | List of parameter names to prevent overwrite for | `list(string)` | `[]` | no |
+| <a name="input_secure_parameters"></a> [secure\_parameters](#input\_secure\_parameters) | Secure parameters | `map(any)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| parameter\_path | n/a |
-| parameters | n/a |
-| secure\_parameters | n/a |
-
+| <a name="output_parameter_path"></a> [parameter\_path](#output\_parameter\_path) | n/a |
+| <a name="output_parameters"></a> [parameters](#output\_parameters) | n/a |
+| <a name="output_secure_parameters"></a> [secure\_parameters](#output\_secure\_parameters) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,10 @@ output "parameter_path" {
 
 output "parameters" {
   value = aws_ssm_parameter.parameters
+  sensitive = true
 }
 
 output "secure_parameters" {
   value = aws_ssm_parameter.secure_parameters
+  sensitive = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,11 @@ output "parameter_path" {
 }
 
 output "parameters" {
-  value = aws_ssm_parameter.parameters
+  value     = aws_ssm_parameter.parameters
   sensitive = true
 }
 
 output "secure_parameters" {
-  value = aws_ssm_parameter.secure_parameters
+  value     = aws_ssm_parameter.secure_parameters
   sensitive = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.14.5"
 
   required_providers {
     aws = ">= 2.41"


### PR DESCRIPTION
# Description

Outputs are now marked as sensitive as required by Terraform 0.15.
Minimum supported Terraform version has been bumped to 0.14.5.
