### PR TITLE
Re-add overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Add versions file for example
+
+
+<a name="3.0.0"></a>
+## [3.0.0] - 2023-09-20
+
+- Add versions file for example ([#5](https://github.com/marcincuber/terraform-aws-ssm-parameters/issues/5))
 - Remove 'overwrite' + updates ([#4](https://github.com/marcincuber/terraform-aws-ssm-parameters/issues/4))
 
 
@@ -36,7 +41,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/3.0.0...HEAD
+[3.0.0]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.2...2.0.0
 [1.0.2]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/marcincuber/terraform-aws-ssm-parameters/compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ No modules.
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The KMS key to use for encryption | `string` | `""` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Path used for each SSM parameter created by the module | `string` | n/a | yes |
 | <a name="input_parameters"></a> [parameters](#input\_parameters) | Non-encrypted parameters | `map(any)` | `{}` | no |
+| <a name="input_prevent_overwrite"></a> [prevent\_overwrite](#input\_prevent\_overwrite) | [Deprecated - will be removed properly in 6.x] List of parameter names to prevent overwrite for | `list(string)` | `[]` | no |
 | <a name="input_secure_parameters"></a> [secure\_parameters](#input\_secure\_parameters) | Secure parameters | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,8 @@ resource "aws_ssm_parameter" "parameters" {
   type  = "String"
   value = each.value
 
-  tier = contains(var.advanced_tier, each.key) ? "Advanced" : "Standard"
+  tier      = contains(var.advanced_tier, each.key) ? "Advanced" : "Standard"
+  overwrite = contains(var.prevent_overwrite, each.key) ? false : true
 
   tags = var.tags
 }
@@ -18,7 +19,8 @@ resource "aws_ssm_parameter" "secure_parameters" {
   value  = each.value
   key_id = var.kms_key_id != "" ? var.kms_key_id : null
 
-  tier = contains(var.advanced_tier, each.key) ? "Advanced" : "Standard"
+  tier      = contains(var.advanced_tier, each.key) ? "Advanced" : "Standard"
+  overwrite = contains(var.prevent_overwrite, each.key) ? false : true
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,3 +31,9 @@ variable "advanced_tier" {
   type        = list(string)
   default     = []
 }
+
+variable "prevent_overwrite" {
+  description = "[Deprecated - will be removed properly in 6.x] List of parameter names to prevent overwrite for"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
# Description

Re-adding overwrite since the functionality of the deprecation warning is not applied yet and errors start cropping up

`ParameterAlreadyExists: The parameter already exists. To overwrite this value, set the overwrite option in the request to true.`